### PR TITLE
ips: allow merging of adjacent intervals for smaller generated ips

### DIFF
--- a/src/asar/libsmw.cpp
+++ b/src/asar/libsmw.cpp
@@ -128,12 +128,12 @@ namespace
 		void queue_for_ips(size_t i_begin, size_t i_end)
 		{
 			for (Interval& interval : intervals)
-				if (interval.i_begin <= i_begin && i_begin < interval.i_end)
+				if (interval.i_begin <= i_begin && i_begin <= interval.i_end)
 				{
 					interval.i_end = std::max(interval.i_end, i_end);
 					return;
 				}
-				else if (interval.i_begin <= i_end && i_end < interval.i_end)
+				else if (interval.i_begin <= i_end && i_end <= interval.i_end)
 				{
 					interval.i_begin = std::min(interval.i_begin, i_begin);
 					return;


### PR DESCRIPTION
Hello,

we've switched to thedopefish asar in our compile chain at VARIA to use the ips generation feature.
the generated ips are too big, that's because asar write its data byte after byte and the ips engine generates a new interval for each byte instead of merging adjacent intervals.

example of ips generated by asar:
0x7BDD1: [0x8],
0x7BDD2: [0xE2],
0x7BDD3: [0x20],

in hex:
07 bd d1  00 01 08
07 bd d2 00 01  e2
07 bd d3 00 01 20

this PR allows the ips engine to merge adjacent intervals.

generated ips with the PR fix:
0x7BDD1: [0x8,0xE2,0x20, ...

in hex:
07 bd d1  00 11 08 e2 20 ...